### PR TITLE
Fix ipynb2pdf A4 layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # ipynb2pdf
 
-ipynb converter -> to pdf
+Convert Jupyter notebooks (.ipynb) to PDF using `wkhtmltopdf`. The included script sets the page size to A4 and preserves all content during conversion.
+

--- a/ipynb2pdf.ipynb
+++ b/ipynb2pdf.ipynb
@@ -72,6 +72,7 @@
     "    \"--margin-bottom\", \"25mm\",\n",
     "    \"--margin-left\", \"25mm\",\n",
     "    \"--margin-right\", \"25mm\",\n",
+    "    \"--page-size\", \"A4\",\n",
     "    html_file_name,\n",
     "    pdf_file_name\n",
     "])\n",


### PR DESCRIPTION
## Summary
- ensure wkhtmltopdf uses A4 when converting notebooks
- document project usage

## Testing
- `python3 -m json.tool ipynb2pdf.ipynb > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_683fb60d1508832cb2fce7cbf3ad4258