### PR TITLE
Add standalone Python script for ipynb to A4 PDF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,90 @@
 # ipynb2pdf
 
-Convert Jupyter notebooks (.ipynb) to PDF using `wkhtmltopdf`. The included script sets the page size to A4 and preserves all content during conversion.
+Convert Jupyter notebooks (.ipynb) to A4 PDF format with proper formatting and margins.
 
+## Features
+
+- Converts .ipynb files to A4-sized PDF documents
+- Preserves code, markdown, and output cells
+- Customizable page margins (default: 25mm)
+- Command-line interface for easy usage
+
+## Installation
+
+### 1. Install wkhtmltopdf
+
+**Ubuntu/Debian:**
+```bash
+sudo apt-get install -y wkhtmltopdf
+```
+
+**macOS:**
+```bash
+brew install wkhtmltopdf
+```
+
+**Windows:**
+Download and install from [wkhtmltopdf.org/downloads.html](https://wkhtmltopdf.org/downloads.html)
+
+### 2. Install Python dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Basic usage
+
+```bash
+python ipynb2pdf.py notebook.ipynb
+```
+
+This will create `notebook.pdf` in the same directory.
+
+### Specify output file
+
+```bash
+python ipynb2pdf.py notebook.ipynb -o output.pdf
+```
+
+### Custom margins
+
+```bash
+python ipynb2pdf.py notebook.ipynb -m 20
+```
+
+This sets all margins to 20mm (default is 25mm).
+
+### All options
+
+```bash
+python ipynb2pdf.py [-h] [-o OUTPUT] [-m MARGIN] input
+
+Arguments:
+  input                 Input .ipynb file path
+  -o, --output OUTPUT   Output .pdf file path
+  -m, --margin MARGIN   Page margin in millimeters (default: 25)
+  -h, --help           Show help message
+```
+
+## Example
+
+```bash
+# Convert notebook to PDF with default settings (A4, 25mm margins)
+python ipynb2pdf.py my_notebook.ipynb
+
+# Convert with custom output path and smaller margins
+python ipynb2pdf.py my_notebook.ipynb -o results/report.pdf -m 15
+```
+
+## Requirements
+
+- Python 3.6+
+- nbformat
+- nbconvert
+- wkhtmltopdf
+
+## License
+
+MIT

--- a/ipynb2pdf.py
+++ b/ipynb2pdf.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+ipynb2pdf: Convert Jupyter notebooks to A4 PDF files
+"""
+import argparse
+import os
+import sys
+import nbformat
+from nbconvert import HTMLExporter
+from subprocess import run, CalledProcessError
+
+
+def check_wkhtmltopdf():
+    """Check if wkhtmltopdf is installed"""
+    try:
+        result = run(['wkhtmltopdf', '--version'], capture_output=True)
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def convert_ipynb_to_pdf(ipynb_path, output_path=None, margin_mm=25):
+    """
+    Convert a Jupyter notebook to A4 PDF
+
+    Args:
+        ipynb_path: Path to the input .ipynb file
+        output_path: Path to the output .pdf file (optional)
+        margin_mm: Margin size in millimeters (default: 25)
+
+    Returns:
+        Path to the generated PDF file
+    """
+    # Check if input file exists
+    if not os.path.exists(ipynb_path):
+        raise FileNotFoundError(f"Input file not found: {ipynb_path}")
+
+    # Check if wkhtmltopdf is installed
+    if not check_wkhtmltopdf():
+        raise RuntimeError(
+            "wkhtmltopdf is not installed. Please install it:\n"
+            "  Ubuntu/Debian: sudo apt-get install -y wkhtmltopdf\n"
+            "  macOS: brew install wkhtmltopdf\n"
+            "  Windows: Download from https://wkhtmltopdf.org/downloads.html"
+        )
+
+    # Determine output path
+    if output_path is None:
+        output_path = ipynb_path.replace('.ipynb', '.pdf')
+
+    # Read the notebook
+    print(f"Reading notebook: {ipynb_path}")
+    with open(ipynb_path, 'r', encoding='utf-8') as f:
+        notebook_content = nbformat.read(f, as_version=4)
+
+    # Setup HTML exporter with embed_images enabled
+    html_exporter = HTMLExporter()
+    html_exporter.exclude_input = False
+    html_exporter.embed_images = True
+
+    # Custom CSS for A4 formatting
+    custom_css = """
+<style>
+    /* Page margins and layout */
+    body {
+        margin: 0;
+        padding: 10px;
+        font-family: Arial, sans-serif;
+    }
+
+    /* Ensure images fit on A4 page */
+    img, .output {
+        max-width: 90%;
+        height: auto;
+    }
+
+    /* Compact cell spacing */
+    .input, .output {
+        margin: 5px 0;
+        padding: 5px;
+        font-size: 12px;
+    }
+
+    /* Code block styling */
+    .input_area {
+        background-color: #f5f5f5;
+        border-left: 3px solid #3b7ea1;
+        padding: 10px;
+        overflow-x: auto;
+    }
+
+    /* Output area styling */
+    .output_area {
+        padding: 5px;
+    }
+
+    /* Prevent page breaks inside code blocks */
+    .cell {
+        page-break-inside: avoid;
+    }
+</style>
+"""
+
+    # Convert to HTML
+    print("Converting to HTML...")
+    html_data, _ = html_exporter.from_notebook_node(notebook_content)
+    html_data = custom_css + html_data
+
+    # Save HTML temporarily
+    html_temp_path = ipynb_path.replace('.ipynb', '_temp.html')
+    with open(html_temp_path, 'w', encoding='utf-8') as f:
+        f.write(html_data)
+
+    # Convert HTML to PDF using wkhtmltopdf with A4 settings
+    print(f"Converting to A4 PDF: {output_path}")
+    try:
+        run([
+            'wkhtmltopdf',
+            '--margin-top', f'{margin_mm}mm',
+            '--margin-bottom', f'{margin_mm}mm',
+            '--margin-left', f'{margin_mm}mm',
+            '--margin-right', f'{margin_mm}mm',
+            '--page-size', 'A4',
+            '--encoding', 'UTF-8',
+            '--enable-local-file-access',
+            '--disable-external-links',
+            '--disable-javascript',
+            '--no-stop-slow-scripts',
+            html_temp_path,
+            output_path
+        ], check=True, capture_output=True)
+    except CalledProcessError as e:
+        print(f"Error during PDF conversion: {e.stderr.decode()}")
+        raise
+    finally:
+        # Clean up temporary HTML file
+        if os.path.exists(html_temp_path):
+            os.remove(html_temp_path)
+
+    print(f"✓ PDF generated successfully: {output_path}")
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert Jupyter notebook (.ipynb) to A4 PDF'
+    )
+    parser.add_argument(
+        'input',
+        help='Input .ipynb file path'
+    )
+    parser.add_argument(
+        '-o', '--output',
+        help='Output .pdf file path (default: same name as input with .pdf extension)'
+    )
+    parser.add_argument(
+        '-m', '--margin',
+        type=int,
+        default=25,
+        help='Page margin in millimeters (default: 25)'
+    )
+
+    args = parser.parse_args()
+
+    try:
+        convert_ipynb_to_pdf(args.input, args.output, args.margin)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+nbformat>=5.0.0
+nbconvert>=7.0.0


### PR DESCRIPTION
- Create ipynb2pdf.py: Command-line tool to convert Jupyter notebooks to A4 PDFs
- Support customizable margins (default 25mm)
- Include wkhtmltopdf check with installation instructions
- Add requirements.txt with nbformat and nbconvert dependencies
- Update README.md with comprehensive usage documentation
- Fix network issues by disabling external resources and JavaScript in wkhtmltopdf